### PR TITLE
add basic version od setup.py

### DIFF
--- a/_meta_value.py
+++ b/_meta_value.py
@@ -268,7 +268,7 @@ class MetaValue(object):
         return  oct(self.__data)
 
     def __hex__(self):
-        return hex(self.__data
+        return hex(self.__data)
 
     def __index__(self):
         return self.__data.__index__()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+setup (name     = 'nc2map',
+    version     = '0.1.0',
+    author      = "Philipp Sommer",
+    author_email= "philipp.sommer@studium.uni-hamburg.de",
+    license     = "GPLv2",
+    description = """ ===================== """,
+    platforms   = ["any"],
+    packages  = ["nc2map"],
+    url         = "https://github.com/Chilipp/nc2map",
+    keywords    = ['netcdf','data','science','plotting'],
+    classifiers = [
+      "Development Status :: 4 - Beta",
+      "Topic :: Utilities",
+      "Operating System :: POSIX",
+      "Programming Language :: Python",
+      ],
+    )
+


### PR DESCRIPTION
hi philipp!
ich hab mal eine basis version von setup.py hinzugefuegt. Damit koenntest du z.b. ein pypi packet erzeugen/hochladen. Damit waere nc2map ziemlich einfach zu installieren und die haettest einen Verteilungsmechismus gratis. Die Basis-Daten sind nur dummys und die Abhaengigkeiten sind aber noch nicht angepasst, momentan kannst du nur mit 

> python setup.py install

installieren. 

hth
ralf
